### PR TITLE
Change symfony/http-foundation requirements

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
   ],
   "require": {
     "symfony/routing": "^4.2",
-    "symfony/http-foundation": "^4.2",
+    "symfony/http-foundation": "^4.2 || ^5.0",
     "creativestyle/magesuite-image-optimization": "^1.0.0",
     "creativestyle/magesuite-image-resize": "^1.0.0"
   },


### PR DESCRIPTION
From Magento 2.4.0 is being using Magento Functional Testing Framework 3.0 - more information:
https://devdocs.magento.com/mftf/docs/introduction.html#find-your-mftf-version

The MFTF from version 3.0.0 require symfony/http-foundation ^5.0:
https://github.com/magento/magento2-functional-testing-framework/blob/3.0.0/composer.json

In this case we need to accept symfony/http-foundation in version 5.x to install this module at Magento 2.4.x.